### PR TITLE
dependencies/SV-6_vscode_folder_exclude

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "python.pythonPath": "/Users/jaqqen/.local/share/virtualenvs/backend-dB0JL0mX/bin/python3",
-  "python.formatting.provider": "yapf"
-}


### PR DESCRIPTION
deleted .vscode-directory from project because this is an individual set up depending on which IDE the user is using